### PR TITLE
Update jcomments.ajax.php

### DIFF
--- a/site/jcomments.ajax.php
+++ b/site/jcomments.ajax.php
@@ -11,6 +11,10 @@
 
 defined('_JEXEC') or die;
 
+ini_set('display_errors', 0);
+ini_set('display_startup_errors', 0);
+error_reporting(0);
+
 ob_start();
 
 if (!defined('JOOMLATUNE_AJAX')) {


### PR DESCRIPTION
Многочисленные ошибки, в частности при отправке жалобы на коммент если идут warning, а они идут, если конечно не выставлено отображение ошибок в Нет
ИМХО для современных версий php, даже начиная с 5,6 актуально.
ЗЫ. Это касается только аякс-ответов, где напрямую варнинги не видны