### PR TITLE
event.preventDefault()

### DIFF
--- a/site/js/jcomments-v2.3.js
+++ b/site/js/jcomments-v2.3.js
@@ -386,12 +386,12 @@ document.addEventListener("DOMContentLoaded", function() {
 		jcomments.clear('captcha');
 	});
 	if (document.getElementById('comments-form-send'))
-	document.getElementById('comments-form-send').addEventListener('click',function () {
-		jcomments.saveComment();return false;
+	document.getElementById('comments-form-send').addEventListener('click',function (e) {
+		e.preventDefault();jcomments.saveComment();return false;
 	});
 	if (document.getElementById('comments-form-cancel'))
-	document.getElementById('comments-form-cancel').addEventListener('click',function () {
-		return false;
+	document.getElementById('comments-form-cancel').addEventListener('click',function (e) {
+		e.preventDefault();return false;
 	});
 	if (document.getElementById('addcomments'))
 	document.getElementById('addcomments').addEventListener('click',function () {


### PR DESCRIPTION
Prevents when you press the send or cancel button, the website jumps to the top of the page.
This problem is caused by `<a href="#">`. Older versions have:
`<a href="#" onclick="jcomments.saveComment();return false;"` but the new versions: addEventListener (jcomments-v2.3.js).

The preventDefault() method cancels the event if it is cancelable. [Link: "https://www.w3schools.com/jsref/event_preventdefault.asp"](https://www.w3schools.com/jsref/event_preventdefault.asp)
