### PR TITLE
3.0.7.7.2 - event.preventDefault()

### DIFF
--- a/administrator/version.php
+++ b/administrator/version.php
@@ -18,13 +18,13 @@ class JCommentsVersion
 	/** @var int Main Release Level */
 	var $RELEASE = '3.0';
 	/** @var int Sub Release Level */
-	var $DEV_LEVEL = '7.7.1';
+	var $DEV_LEVEL = '7.7.2';
 	/** @var string Development Status */
 	var $DEV_STATUS = '';
 	/** @var int Build Number */
 	var $BUILD = '';
 	/** @var string Date */
-	var $RELDATE = '29/04/2021';
+	var $RELDATE = '23/05/2021';
 	/** @var string Time */
 	var $RELTIME = '00:26';
 	/** @var string Timezone */

--- a/jcomments.xml
+++ b/jcomments.xml
@@ -7,7 +7,7 @@
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<copyright>Copyright 2006-2018 JoomlaTune.ru All rights reserved!</copyright>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>3.0.7.7.1</version>
+	<version>3.0.7.7.2</version>
 	<description><![CDATA[JComments lets your users comment on content items.]]></description>
 
 	<scriptfile>script.jcomments.php</scriptfile>

--- a/site/changelog.php
+++ b/site/changelog.php
@@ -12,6 +12,30 @@ defined('_JEXEC') or die;
 
 Changelog
 ------------
+3.0.7.7.2 - Unofficial version
+# Fixed when you press the send or cancel button, the website jumps to the top of the page.
+^ Updated "tpl_form.php" file. Added a missing php end-tag.
+
+3.0.7.7 - Unofficial version
+# Fix countable error in template
+
+3.0.7.6 - Unofficial version
++ Adapted for joomla 4.0
+^ Modified About JComments, it shows JComments version and link to github project
++ Added backend option to show/hide a checkbox to "Accept terms of use"
+^ Updated ALL frontend languages: added FORM_ACCEPT_TERMS_OF_USE and ERROR_CHECKBOX_TERMS_OF_USE_NO_SELECTED tags.
+^ Backend Russian and English languages updated: added AP_ENABLE_ACCEPT_TERMS_OF_USE, AP_ENABLE_ACCEPT_TERMS_OF_USE_DESC and A_ABOUT_JCOMMENTS_GITHUB_PROJECT tags.
+^ Responsive form (style.css)
+^ Redirect component from index.php to homepage
+# Fixed error in recaptcha v2. Deleted RECAPTCHA item in JComments CAPTCHA options. ERROR fixed: disable recaptcha v2 from Joomla plugins and then select RECAPTCHA option in JComments.
+
+3.0.7.1 to 3.0.7.5 - Unofficial version
+  (Modified version of official v3.0.7 (Github project: https://github.com/exstreme/Jcomments-Recaptcha2))
++ Added PHP 7.2 compatibility
++ Added reCAPTCHA v2 and invisible reCAPTCHA from Joomla! plugins
+^ Added noopener to link to joomlatune site for security
+^ Speed optimization.
+and more...
 
 3.0.6
 * Security fix (processing ajax function calls)
@@ -98,13 +122,6 @@ Changelog
 ^ The JComments backend now uses native Joomla's code with MVC
 ^ The JComments installer uses Joomla API to install additional plugins
 ^ Huge code improvements and optimizations
-
-3.7.6
-+ adapted for joomla 4.0
-+ Added "Accept terms of use" checkbox
-
-3.7.6
-# Countable error in template
 
 * -> Security Fix
 # -> Bug Fix

--- a/site/js/jcomments-v2.3.js
+++ b/site/js/jcomments-v2.3.js
@@ -386,12 +386,12 @@ document.addEventListener("DOMContentLoaded", function() {
 		jcomments.clear('captcha');
 	});
 	if (document.getElementById('comments-form-send'))
-	document.getElementById('comments-form-send').addEventListener('click',function () {
-		jcomments.saveComment();return false;
+	document.getElementById('comments-form-send').addEventListener('click',function (e) {
+		e.preventDefault();jcomments.saveComment();return false;
 	});
 	if (document.getElementById('comments-form-cancel'))
-	document.getElementById('comments-form-cancel').addEventListener('click',function () {
-		return false;
+	document.getElementById('comments-form-cancel').addEventListener('click',function (e) {
+		e.preventDefault();return false;
 	});
 	if (document.getElementById('addcomments'))
 	document.getElementById('addcomments').addEventListener('click',function () {

--- a/site/tpl/default/tpl_form.php
+++ b/site/tpl/default/tpl_form.php
@@ -350,3 +350,4 @@ else {if (typeof window.onload=='function'){var oldload=window.onload;window.onl
         }
     }
 }
+?>


### PR DESCRIPTION
Prevents when you press the send or cancel button, the website jumps to the top of the page.
This problem is caused by `<a href="#">`. Older versions have:
`<a href="#" onclick="jcomments.saveComment();return false;` but the new versions: addEventListener (jcomments-v2.3.js).
The preventDefault() method cancels the event if it is cancelable. Link: "[https://www.w3schools.com/jsref/event_preventdefault.asp](https://www.w3schools.com/jsref/event_preventdefault.asp)"

 Fixed when you press the send or cancel button, the website jumps to the top of the page.
 Updated "tpl_form.php" file. Added a missing php end-tag.