### PR TITLE
Added message while mark comment(s) as deleted.

### DIFF
--- a/administrator/language/en-GB/en-GB.com_jcomments.ini
+++ b/administrator/language/en-GB/en-GB.com_jcomments.ini
@@ -49,6 +49,8 @@ A_COMMENT_TITLE="Comment title"
 A_COMMENT_TITLE_RE="RE:"
 A_COMMENT_TEXT="Comment text"
 A_COMMENT_HAS_BEEN_DELETED="This comment has been deleted by Administrator"
+A_COMMENTS_HAS_BEEN_MARKED_N_DELETED="%d comments are marked as deleted."
+A_COMMENTS_HAS_BEEN_MARKED_N_DELETED_1="%d comment are marked as deleted."
 
 ; settings
 A_SETTINGS="Settings"

--- a/administrator/language/ru-RU/ru-RU.com_jcomments.ini
+++ b/administrator/language/ru-RU/ru-RU.com_jcomments.ini
@@ -49,6 +49,9 @@ A_COMMENT_TITLE="Тема"
 A_COMMENT_TITLE_RE="RE:"
 A_COMMENT_TEXT="Текст комментария"
 A_COMMENT_HAS_BEEN_DELETED="Комментарий был удален администратором"
+A_COMMENTS_HAS_BEEN_MARKED_N_DELETED="%d комментариев отмечены как удаленные."
+A_COMMENTS_HAS_BEEN_MARKED_N_DELETED_1="%d комментарий отмечен как удаленный."
+A_COMMENTS_HAS_BEEN_MARKED_N_DELETED_2="%d комментария отмечены как удаленные."
 
 ; settings
 A_SETTINGS="Настройка параметров"

--- a/administrator/models/comments.php
+++ b/administrator/models/comments.php
@@ -133,6 +133,7 @@ class JCommentsModelComments extends JCommentsModelList
 	{
 		$pks = (array)$pks;
 		$table = $this->getTable();
+		$total = count($pks);
 
 		foreach ($pks as $i => $pk) {
 			if ($table->load($pk)) {
@@ -147,6 +148,7 @@ class JCommentsModelComments extends JCommentsModelList
 						}
 					} else {
 						$table->markAsDeleted();
+						JFactory::getApplication()->enqueueMessage(JText::plural('A_COMMENTS_HAS_BEEN_MARKED_N_DELETED', $total));
 					}
 				} else {
 					unset($pks[$i]);


### PR DESCRIPTION
When option `Delete mode` is set to `Mark as deleted` when no messages displayed when we try to delete a comment(s). This PR will fix it.